### PR TITLE
framel v8.40.5

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,13 +1,15 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 numpy:
 - '1.16'
 - '1.16'
@@ -25,5 +27,7 @@ python:
 target_platform:
 - linux-64
 zip_keys:
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,13 +7,6 @@
     replace('r', '.', 1)|
     replace('p', '.', 1)
  %}
-#{% set minor = version|split('r')[1]|split('p')[0] %}
-#{% if "p" in version %}
-#{% set patch = version|split('p')[1] %}
-#{% else %}
-#{% set patch = "0" %}
-#{% endif %}
-#{% set semver_version = major + "." + minor + "." + patch %}
 
 package:
   name: {{ name|lower }}-split

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,27 @@
 {% set name = "framel" %}
-{% set version = "8.40.1" %}
+{% set version = "v8r40p5" %}
+
+# handle Virgo version number format
+{% set semver_version = version|
+    replace('v', '', 1)|
+    replace('r', '.', 1)|
+    replace('p', '.', 1)
+ %}
+#{% set minor = version|split('r')[1]|split('p')[0] %}
+#{% if "p" in version %}
+#{% set patch = version|split('p')[1] %}
+#{% else %}
+#{% set patch = "0" %}
+#{% endif %}
+#{% set semver_version = major + "." + minor + "." + patch %}
 
 package:
   name: {{ name|lower }}-split
-  version: {{ version }}
+  version: {{ semver_version }}
 
 source:
-  url: http://software.igwn.org/sources/source/{{ name }}-{{ version }}.tar.xz
-  sha256: ea4afcdf839f8eb49edc2d3190b5aebb08871146e426b644887f7efbae30a6b9
+  url: https://git.ligo.org/virgo/virgoapp/Fr/-/archive/{{ version }}/Fr-{{ version }}.tar.gz
+  sha256: 2fd2e76e5cc5739433ba2c00726dc8eb2bd14f2e3daaa0d9e203f669d6cbbf9e
   patches:
     # mkdir on mingw only takes one argument
     - mkdir.patch  # [win]
@@ -15,7 +29,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 2
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,8 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage("libframel", max_pin="x") }}
+      ignore_run_exports:
+        - m2w64-gcc-libs  # [win]
     requirements:
       build:
         - {{ compiler('c') }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,6 +73,9 @@ outputs:
         files.
 
   - name: framel
+    build:
+      ignore_run_exports:
+        - m2w64-gcc-libs  # [win]
     requirements:
       build:
         - {{ compiler('c') }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,6 +121,7 @@ outputs:
     build:
       ignore_run_exports:
         - python  # [osx]
+        - m2w64-gcc-libs  # [win]
     requirements:
       build:
         - {{ compiler('c') }}  # [not win]


### PR DESCRIPTION
This PR updates the feedstock to 8.40.5 - releases are no longer uploaded in the same way so we transition to using the gitlab automatic tarballs and the Fr native versioning scheme, with some hacky munging of that into something semver-ish.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
